### PR TITLE
Partial correction issue with nbody example in subscreenSpec5.xml; 

### DIFF
--- a/src/XMLScreens/RomeoLib.jl
+++ b/src/XMLScreens/RomeoLib.jl
@@ -122,7 +122,7 @@ function init_romeo( vObjT::SubScreen ;
              error("Unknown or absent key for TBCompleted ")
           end
       end
-      if isa(vo, Tuple)
+      if isa(vo, Tuple) || isa(vo, Array{RenderObject,1})
          return map( v -> visualizeConduit( v, camera, scr), vo)
       end
 
@@ -333,6 +333,7 @@ function interact_loop(builtDict::Dict{Tuple{Symbol,Symbol},Any})
 
    # perform the updates of the signals
    while GLVisualize.ROOT_SCREEN.inputs[:open].value
+         yield()
          performSignalUpdts(builtDict)
    end
 

--- a/src/XMLScreens/SemXMLSubscreen.jl
+++ b/src/XMLScreens/SemXMLSubscreen.jl
@@ -629,22 +629,27 @@ end
 function  performSignalUpdts(bDict::Dict{Tuple{Symbol,Symbol},Any})
    #println ("Entering performSignalUpdts:")
    #showBD(bDict)
+   called = false
    if haskey( bDict, (:signalFnList,:list))
       for sFName in bDict[(:signalFnList,:list)] 
           initDict = bDict[(:signalFn,sFName)]
           if haskey(initDict,:advance)
              updtFnName= initDict[:advance]
              fn = searchCallable( updtFnName, bDict)
+             called = true
              if haskey( bDict, (:sigInitVal,sFName))
                 # access the signal
                 sig =  bDict[(:sigInitVal,sFName)]
                  fn(sig)
              else
-                 fn()
+                 fn()        
              end
           end
       end
    end    
+   called || sleep(0.01) #just an experiment, this makes some
+                         #cases where a realtime (e.g. frequency generated) 
+                         #signal is used.
    #println ("Exiting performSignalUpdts")
 end
 # Provide a function to insert the functions prepared in the application

--- a/src/XMLScreens/SemXMLSubscreen.jl
+++ b/src/XMLScreens/SemXMLSubscreen.jl
@@ -627,8 +627,8 @@ function  performInits(bDict::Dict{Tuple{Symbol,Symbol},Any})
    println ("Exiting performInits")
 end
 function  performSignalUpdts(bDict::Dict{Tuple{Symbol,Symbol},Any})
-   println ("Entering performSignalUpdts:")
-   showBD(bDict)
+   #println ("Entering performSignalUpdts:")
+   #showBD(bDict)
    if haskey( bDict, (:signalFnList,:list))
       for sFName in bDict[(:signalFnList,:list)] 
           initDict = bDict[(:signalFn,sFName)]
@@ -645,7 +645,7 @@ function  performSignalUpdts(bDict::Dict{Tuple{Symbol,Symbol},Any})
           end
       end
    end    
-   println ("Exiting performSignalUpdts")
+   #println ("Exiting performSignalUpdts")
 end
 # Provide a function to insert the functions prepared in the application
 # code into the xmlNS

--- a/test/subscreenSpec4.xml
+++ b/test/subscreenSpec4.xml
@@ -171,10 +171,11 @@ function worldCreate()
    r0[4,:] = [0,0,0.0]
 
    #Select a reasonable set of speeds (avoid cases where
-   #       a singularity happens stopping the ode solver
+   #       a singularity happens stopping the ode solver. Arrange for
+   #       a null momentum so that the world stays on the screen. )
    v0 = rand(n,3)
-
-
+   mv = m' * v0 / sum(m)
+   v0 = v0 - ones(4,1) * mv
     
    # Aggregate initial data (position, speed)  in a format that
    # the ODE solver and function F handle

--- a/test/subscreenSpec4.xml
+++ b/test/subscreenSpec4.xml
@@ -3,10 +3,88 @@
              xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
 
 <!-- Test purposes
-     1) explore GLVisualize examples, here nbody.jl
-     2) include signal timed displays (with all the machinery there TBD)
+     1) explore GLVisualize examples, here nbody.jl           
+     2) include signal timed displays (with all the machinery 
+     3) Use multiple <inline> tags (in different modules), including 
+        cross referencing (see the doAxis function nelow)
+     4) Test mixing of signal based and static (non signal based) display
 -->
 <!-- Function definitions  -->
+
+<julia  modulename="SubScreensInline2">
+   <inline>
+   <?julia      
+      module SubScreensInline2
+
+      using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+      using ColorTypes, GeometryTypes
+      using Meshes, MeshIO
+      using Romeo, TBCompletedM
+
+      export doMesh, doAxis, doMeshAxis
+      
+      warn ("GLAbstraction.Camera is not exported")
+      Camera = GLAbstraction.Camera
+
+      ## Example from GLVisualize/test/test_mesh
+      function create_example_mesh()
+          # volume of interest
+          x_min, x_max = -1, 15
+          y_min, y_max = -1, 5
+          z_min, z_max = -1, 5
+          scale = 8
+       
+          b1(x,y,z) = box(   x,y,z, 0,0,0,3,3,3)
+          s1(x,y,z) = sphere(x,y,z, 3,3,3,sqrt(3))
+          f1(x,y,z) = min(b1(x,y,z), s1(x,y,z))  # UNION
+          b2(x,y,z) = box(   x,y,z, 5,0,0,8,3,3)
+          s2(x,y,z) = sphere(x,y,z, 8,3,3,sqrt(3))
+          f2(x,y,z) = max(b2(x,y,z), -s2(x,y,z)) # NOT
+          b3(x,y,z) = box(   x,y,z, 10,0,0,13,3,3)
+          s3(x,y,z) = sphere(x,y,z, 13,3,3,sqrt(3))
+          f3(x,y,z) = max(b3(x,y,z), s3(x,y,z))  # INTERSECTION
+          f(x,y,z) = min(f1(x,y,z), f2(x,y,z), f3(x,y,z))
+       
+          vol = volume(f, x_min,y_min,z_min,x_max,y_max,z_max, scale)
+          msh = GLNormalMesh(vol, 0.0f0)
+          return msh
+      end
+
+      function create_example_axis()
+        dirlen 	= 1f0
+        baselen = 0.02f0
+        axis 	= [
+      	 (Cube(Vec3(baselen), Vec3(dirlen, baselen, baselen)), RGBA(1f0,0f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, dirlen, baselen)), RGBA(0f0,1f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, baselen, dirlen)), RGBA(0f0,0f0,1f0,1f0))
+          ]
+        axis = map(GLNormalMesh, axis)
+        axis = merge(axis)
+      end
+
+      function doMesh(sc::Screen,cam::Camera)
+          println("Entered doMesh")
+	  msh  = create_example_mesh()
+          msh
+      end
+
+     function doAxis (sc::Screen,cam::Camera)
+          println("Entered doAxis")
+          ax   = create_example_axis()
+          ax
+     end
+
+     function doMeshAxis (sc::Screen,cam::Camera)
+          println("Entered doMeshAxis")
+	  msh  = create_example_mesh()
+          ax   = create_example_axis()
+          (msh,ax)
+     end
+
+      end    # SubScreensInline2
+   ?>
+   </inline>
+</julia>
 
 
 <julia  modulename="SubScreensInline">
@@ -25,6 +103,9 @@ using Meshes, MeshIO
 using Reactive
 using Romeo, TBCompletedM
 using ODE
+
+using xmlNS.SubScreensInline2
+
 
 export doPlanets,  timerInitFun, timerAdvanceFun
       
@@ -156,19 +237,26 @@ function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result
     lenPlanet = len    
 
     const positions     = lift(send_frame, time_i, Input(planets))
-    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)), 
+                                    screen=sc, camera=cam)
 
 
     const robjPl  = [ visualize(
     				reshape(planets[:, i], (round(Int,len/20), 20)),
 				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
-    				model=scalematrix(Vec3(0.01f0)))
+    				model=scalematrix(Vec3(0.01f0)),
+                                screen=sc, camera=cam)
                        for i=1:4]
 
     # for now I have an issue with the second (robjPl)
-    #return (robj, robjPl, len) 
+    for ro in robjPl
+        println("typeof(ro):", typeof(ro))
+    end
+    robjPlTy = Array{RenderObject,1}(robjPl)   #::Array{RenderObject,1}
 
-    return robj
+
+    return (robj, robjPlTy, doAxis(sc,cam)) 
+    #return robj
 end
 
 
@@ -192,14 +280,6 @@ For checking:
 
 push!(GLVisualize.ROOT_SCREEN.renderlist, robj)
 append!(GLVisualize.ROOT_SCREEN.renderlist, planet_lines)
-
-@async renderloop() 
-# you can also "manually" push into the signal. For that the renderloop has to be 
-# started asynchronous while the loop that updates the signal is the blocking one
-while GLVisualize.ROOT_SCREEN.inputs[:open].value
-    yield()
-    push!(time_i, mod1(time_i.value+1, lenPlanet))
-end
 
 ==#
    ?>
@@ -245,6 +325,18 @@ end
  <setplot  ref="B1"  fn="doPlanets">
        <addparm name="timer" />
  </setplot>
+
+ <setplot  ref="IA1"  fn="doMeshAxis"/>
+ <setplot  ref="IB1"  fn="doMeshAxis"> 
+      <rotateModel>Pi/2, 0.0, 0.0</rotateModel>
+ </setplot>
+ <setplot  ref="IC1"  fn="doMeshAxis">
+      <rotateModel>0.0, Pi/2, 0.0</rotateModel>
+ </setplot>
+ <setplot  ref="ID1"  fn="doMeshAxis">
+      <rotateModel>0.0, 0.0, Pi/2</rotateModel>
+ </setplot>
+ <setplot  ref="A2"  fn="doAxis"/>
 
  <!-- Connectors -->
 

--- a/test/subscreenSpec5.xml
+++ b/test/subscreenSpec5.xml
@@ -1,22 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
 
 <!-- Test purposes
-     1) Add the planet lines to test subscreenSpec4.xml
-     2) If all goes well, add  views in speed / kinetic energy spaces
+     1) explore GLVisualize examples, here nbody.jl
+     2) include signal timed displays (with all the machinery
+     3) If all goes well, add  views in speed / kinetic energy spaces
+     4) Test sharing of user data (not RenderObject)
 -->
 <!-- Function definitions  -->
 
 
+<julia  modulename="SubScreensInline2">
+   <inline>
+   <?julia      
+      module SubScreensInline2
+
+      using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+      using ColorTypes, GeometryTypes
+      using Meshes, MeshIO
+      using Romeo, TBCompletedM
+
+      export doMesh, doAxis, doMeshAxis
+      
+      warn ("GLAbstraction.Camera is not exported")
+      Camera = GLAbstraction.Camera
+
+      function create_example_axis()
+        dirlen 	= 1f0
+        baselen = 0.02f0
+        axis 	= [
+      	 (Cube(Vec3(baselen), Vec3(dirlen, baselen, baselen)), RGBA(1f0,0f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, dirlen, baselen)), RGBA(0f0,1f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, baselen, dirlen)), RGBA(0f0,0f0,1f0,1f0))
+          ]
+        axis = map(GLNormalMesh, axis)
+        axis = merge(axis)
+      end
+
+     function doAxis (sc::Screen,cam::Camera)
+          println("Entered doAxis")
+          ax   = create_example_axis()
+          ax
+     end
+      end    # SubScreensInline2
+   ?>
+   </inline>
+</julia>
+
+
+
 <julia  modulename="SubScreensInline">
-   <signal name="timer"  
-           init="timerInitFun" 
+   <signal name="timer"
+           init="timerInitFun"
            advance="timerAdvanceFun"
            type="Reactive.Input{Int64}"/>
    <!-- now  read the inlined Julia code -->
    <inline>
-   <?julia      
+   <?julia
 module SubScreensInline
 
 using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
@@ -26,17 +67,19 @@ using Reactive
 using Romeo, TBCompletedM
 using ODE
 
-export doPlanets,  timerInitFun, timerAdvanceFun
-      
+using xmlNS.SubScreensInline2
+
+export doPlanets,  doPlanetSpeeds, timerInitFun, timerAdvanceFun
+
 warn ("GLAbstraction.Camera is not exported")
 Camera = GLAbstraction.Camera
 
       ## Example from GLVisualize/test/nbody.jl
 function F(t,y)
-    
+
     #Number of Planets (note we're solving the n-body problem, rather than just a 3-body problem)
     n = int(length(y)/6)
-    
+
     #Extract current position and velocity
     r = zeros(n,3)
     v = zeros(n,3)
@@ -44,10 +87,10 @@ function F(t,y)
         r[i,:] = y[(i-1)*6+1:(i-1)*6+3]
         v[i,:] = y[(i-1)*6+4:(i-1)*6+6]
     end
-        
+
     #Calculate spatial derivatives
     drdt = v
-        
+
     #Work out velocity derivatives (ie accelerations)
     dvdt = zeros(n,3)
     for i = 1:n
@@ -57,7 +100,7 @@ function F(t,y)
             end
         end
     end
-    
+
     #Combine back together into dydt vector
     dydt = zeros(6*n)
     for i = 1:n
@@ -74,7 +117,7 @@ end  # Function F(t,y)
 function worldCreate()
 
    #Set the masses
-   global m 
+   global m
    m = [5,4,3,5]
    n = length(m)
 
@@ -82,7 +125,7 @@ function worldCreate()
    global G
    G = .2
 
-   #Set initial positions and velocities 
+   #Set initial positions and velocities
    r0 = zeros(n,3)
    r0[1,:] = [1.0,-1.0,1.0]
    r0[2,:] = [1,3,0.0]
@@ -94,7 +137,7 @@ function worldCreate()
    v0 = rand(n,3)
 
 
-    
+
    # Aggregate initial data (position, speed)  in a format that
    # the ODE solver and function F handle
    y0 = zeros(6*n)
@@ -118,13 +161,35 @@ function worldOperate(y0)
    return t,y
 end
 
+function worldStore()
+    global world
+    if !isdefined(:world)
+        m,y0,G = worldCreate()
+        t,y    = worldOperate(y0)
+        planets      = reformatData(m, t, y)
+        planetspeeds = reformatSpeeds(m, t, y)
+        len= size(planets, 1)
+        world = WorldType(m, length(m), y0, G, t, y, planets, planetspeeds, len)
+    end
+end
+
+function mkParticleColors(n::Int)
+    global particleColors
+    if !isdefined(:particleColors)
+          particleColors = Array{Any,1}(n)
+          for i in 1:n
+             particleColors[i] =  RGBA(rand(Float32,3)..., 0.4f0)
+          end
+    end
+end
+
 function send_frame(i, planets)
     p = planets[i, 1:4]
     reshape(p, (2,2))
 end
 
 function reformatData(m, t, y)
-    #Extract the data into a useful form 
+    #Extract the data into a useful form
     n = length(m)
     ymat= hcat(y...)
 
@@ -135,58 +200,116 @@ function reformatData(m, t, y)
                       [6(i-1)+3 for i = 1:n]])
     rcoords = convert(Array{Int64,1}, rcoords)
     const r = map(Float32, ymat[rcoords,:])
-    
+
     const planets = hcat( [ reinterpret(Point3{Float32},
                                         r[3(i-1)+1:3(i-1)+3,:],
                                         (size(r, 2),)) for i=1:n]...)
-    println("size(planets[:, 1]=", size(planets[:, 1]))                                            
+    println("size(planets[:, 1]=", size(planets[:, 1]))
     return planets
 end
 
 
+function reformatSpeeds(m, t, y)
+    #Extract the data into a useful form
+    n = length(m)
+    ymat= hcat(y...)
 
-function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result   
-    m,y0,G = worldCreate()
-    t,y    = worldOperate(y0)  
-    planets = reformatData(m, t, y)
-    len= size(planets, 1)
+    # gather some results, do we need to construct such an array
+    # positions
+    rcoords = sort([  [6(i-1)+4 for i = 1:n],
+                      [6(i-1)+5 for i = 1:n],
+                      [6(i-1)+6 for i = 1:n]])
+    rcoords = convert(Array{Int64,1}, rcoords)
+    const r = map(Float32, ymat[rcoords,:])
+
+    const speeds = hcat( [ reinterpret(Point3{Float32},
+                                        r[3(i-1)+1:3(i-1)+3,:],
+                                        (size(r, 2),)) for i=1:n]...)
+    return speeds
+end
+
+
+type WorldType
+     masses
+     nb
+     yInit
+     G
+     tsteps
+     YV
+     planets
+     speeds
+     lenPlanets
+end
+
+
+function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result
+    global world
+    worldStore()
+    global particleColors
+    mkParticleColors(world.nb)
 
     # this is used for communication with timerAdvanceFun
-    global lenPlanet
-    lenPlanet = len    
+    lenPlanet =  world.lenPlanets
 
-    const positions     = lift(send_frame, time_i, Input(planets))
-    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+    const positions     = lift(send_frame, time_i, Input(world.planets))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)),
+                                    screen=sc, camera=cam)
 
 
-    const robjPl  = [ visualize(
-    				reshape(planets[:, i], (round(Int,len/20), 20)),
-				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
-    				model=scalematrix(Vec3(0.01f0)))
+    const robjPl  = [ visualize(reshape(world.planets[:, i], (round(Int,lenPlanet/20), 20)),
+				particle_color= particleColors[i],
+    				model=scalematrix(Vec3(0.01f0)),
+                                screen=sc, camera=cam)
                        for i=1:4]
 
-    # for now I have an issue with the second (robjPl)
-    for ro in robjPl
-        println("typeof(ro):", typeof(ro))
-    end
-    robjPlTy = Array{RenderObject,1}(robjPl)   #::Array{RenderObject,1}
-    @show robjPlTy
+    # this conversion is required, otherwise loss of type information
+    robjPlTy = Array{RenderObject,1}(robjPl)
 
-    return (robj, robjPlTy) 
-    #return robj
+    return (robj, robjPlTy, doAxis(sc,cam))
 end
+
+function doPlanetSpeeds( sc::Screen,cam::Camera, time_i) # beware 3rd result
+    global world
+    worldStore()
+    global particleColors
+    mkParticleColors(world.nb)
+
+    # this is used for communication with timerAdvanceFun
+    lenPlanet =  world.lenPlanets
+
+    speedScale= 3.0
+    @show typeof(world.speeds)
+    const posSpeeds   = lift(send_frame, time_i, Input(world.speeds))
+    const robjSpeed   = visualize(posSpeeds, model=scalematrix(Vec3(0.3f0)),
+                                  screen=sc, camera=cam)
+
+
+    const robjPl  = [ visualize( reshape( world.speeds[:, i] , 
+                                         (round(Int,lenPlanet/20), 20)),
+		particle_color= particleColors[i],
+    		model=scalematrix(Vec3(0.03f0)), 
+                screen=sc, camera=cam)
+                for i=1:4]
+
+    # this conversion is required, otherwise loss of type information
+    robjPlTy = Array{RenderObject,1}(robjPl)
+
+    return (robjSpeed, robjPlTy, doAxis(sc,cam))
+end
+
 
 
 #  provide the timing signal:
 function timerInitFun()
    println("In timerInitFun")
-   return Input(1) 
+   return Input(1)
 end
 
 # How do we get lenPlanet in there?
 function timerAdvanceFun(timer::Reactive.Input{Int64})
-    global lenPlanet
-    push!(timer, mod1(timer.value+1, lenPlanet))
+    global world
+
+    push!(timer, mod1(timer.value+1, world.lenPlanets))
 end
 
 
@@ -197,14 +320,6 @@ For checking:
 
 push!(GLVisualize.ROOT_SCREEN.renderlist, robj)
 append!(GLVisualize.ROOT_SCREEN.renderlist, planet_lines)
-
-@async renderloop() 
-# you can also "manually" push into the signal. For that the renderloop has to be 
-# started asynchronous while the loop that updates the signal is the blocking one
-while GLVisualize.ROOT_SCREEN.inputs[:open].value
-    yield()
-    push!(time_i, mod1(time_i.value+1, lenPlanet))
-end
 
 ==#
    ?>
@@ -248,6 +363,25 @@ end
 <!-- Subscreen contents -->
 
  <setplot  ref="B1"  fn="doPlanets">
+       <addparm name="timer" />
+ </setplot>
+
+ <setplot  ref="IB1"  fn="doPlanets">
+       <addparm name="timer" />
+       <rotateModel>Pi/2, 0.0, 0.0</rotateModel>
+ </setplot>
+
+ <setplot  ref="IC1"  fn="doPlanets">
+       <addparm name="timer" />
+       <rotateModel>0.0, Pi/2, 0.0</rotateModel>
+ </setplot>
+
+ <setplot  ref="ID1"  fn="doPlanets">
+       <addparm name="timer" />
+       <rotateModel>0.0, 0.0, Pi/2</rotateModel>
+ </setplot>
+
+ <setplot  ref="A2"  fn="doPlanetSpeeds">
        <addparm name="timer" />
  </setplot>
 

--- a/test/subscreenSpec5.xml
+++ b/test/subscreenSpec5.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
+
+<!-- Test purposes
+     1) Add the planet lines to test subscreenSpec4.xml
+     2) If all goes well, add  views in speed / kinetic energy spaces
+-->
+<!-- Function definitions  -->
+
+
+<julia  modulename="SubScreensInline">
+   <signal name="timer"  
+           init="timerInitFun" 
+           advance="timerAdvanceFun"
+           type="Reactive.Input{Int64}"/>
+   <!-- now  read the inlined Julia code -->
+   <inline>
+   <?julia      
+module SubScreensInline
+
+using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+using ColorTypes, GeometryTypes
+using Meshes, MeshIO
+using Reactive
+using Romeo, TBCompletedM
+using ODE
+
+export doPlanets,  timerInitFun, timerAdvanceFun
+      
+warn ("GLAbstraction.Camera is not exported")
+Camera = GLAbstraction.Camera
+
+      ## Example from GLVisualize/test/nbody.jl
+function F(t,y)
+    
+    #Number of Planets (note we're solving the n-body problem, rather than just a 3-body problem)
+    n = int(length(y)/6)
+    
+    #Extract current position and velocity
+    r = zeros(n,3)
+    v = zeros(n,3)
+    for i=1:n
+        r[i,:] = y[(i-1)*6+1:(i-1)*6+3]
+        v[i,:] = y[(i-1)*6+4:(i-1)*6+6]
+    end
+        
+    #Calculate spatial derivatives
+    drdt = v
+        
+    #Work out velocity derivatives (ie accelerations)
+    dvdt = zeros(n,3)
+    for i = 1:n
+        for j = 1:n
+            if i != j
+                dvdt[i,:] += -G*m[j]*(r[i,:]-r[j,:])/(norm(r[i,:]-r[j,:])^3)
+            end
+        end
+    end
+    
+    #Combine back together into dydt vector
+    dydt = zeros(6*n)
+    for i = 1:n
+        dydt[6(i-1)+1] = drdt[i,1]
+        dydt[6(i-1)+2] = drdt[i,2]
+        dydt[6(i-1)+3] = drdt[i,3]
+        dydt[6(i-1)+4] = dvdt[i,1]
+        dydt[6(i-1)+5] = dvdt[i,2]
+        dydt[6(i-1)+6] = dvdt[i,3]
+    end
+    return dydt
+end  # Function F(t,y)
+
+function worldCreate()
+
+   #Set the masses
+   global m 
+   m = [5,4,3,5]
+   n = length(m)
+
+   #Set the gravitational field strength
+   global G
+   G = .2
+
+   #Set initial positions and velocities 
+   r0 = zeros(n,3)
+   r0[1,:] = [1.0,-1.0,1.0]
+   r0[2,:] = [1,3,0.0]
+   r0[3,:] = [-1,-2,0.0]
+   r0[4,:] = [0,0,0.0]
+
+   #Select a reasonable set of speeds (avoid cases where
+   #       a singularity happens stopping the ode solver
+   v0 = rand(n,3)
+
+
+    
+   # Aggregate initial data (position, speed)  in a format that
+   # the ODE solver and function F handle
+   y0 = zeros(6*n)
+   for i = 1:n
+     y0[6(i-1)+1] = r0[i,1]
+     y0[6(i-1)+2] = r0[i,2]
+     y0[6(i-1)+3] = r0[i,3]
+     y0[6(i-1)+4] = v0[i,1]
+     y0[6(i-1)+5] = v0[i,2]
+     y0[6(i-1)+6] = v0[i,3]
+   end
+    return (m,y0,G)
+end
+
+function worldOperate(y0)
+   #Solve the system
+   tf = 10
+   stepsPerUnitTime = 200
+   tspan = linspace(0,tf,tf*stepsPerUnitTime)
+   t,y = ode23s(F, y0, tspan; points=:specified);
+   return t,y
+end
+
+function send_frame(i, planets)
+    p = planets[i, 1:4]
+    reshape(p, (2,2))
+end
+
+function reformatData(m, t, y)
+    #Extract the data into a useful form 
+    n = length(m)
+    ymat= hcat(y...)
+
+    # gather some results, do we need to construct such an array
+    # positions
+    rcoords = sort([  [6(i-1)+1 for i = 1:n],
+                      [6(i-1)+2 for i = 1:n],
+                      [6(i-1)+3 for i = 1:n]])
+    rcoords = convert(Array{Int64,1}, rcoords)
+    const r = map(Float32, ymat[rcoords,:])
+    
+    const planets = hcat( [ reinterpret(Point3{Float32},
+                                        r[3(i-1)+1:3(i-1)+3,:],
+                                        (size(r, 2),)) for i=1:n]...)
+    println("size(planets[:, 1]=", size(planets[:, 1]))                                            
+    return planets
+end
+
+
+
+function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result   
+    m,y0,G = worldCreate()
+    t,y    = worldOperate(y0)  
+    planets = reformatData(m, t, y)
+    len= size(planets, 1)
+
+    # this is used for communication with timerAdvanceFun
+    global lenPlanet
+    lenPlanet = len    
+
+    const positions     = lift(send_frame, time_i, Input(planets))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+
+
+    const robjPl  = [ visualize(
+    				reshape(planets[:, i], (round(Int,len/20), 20)),
+				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
+    				model=scalematrix(Vec3(0.01f0)))
+                       for i=1:4]
+
+    # for now I have an issue with the second (robjPl)
+    for ro in robjPl
+        println("typeof(ro):", typeof(ro))
+    end
+    robjPlTy = Array{RenderObject,1}(robjPl)   #::Array{RenderObject,1}
+    @show robjPlTy
+
+    return (robj, robjPlTy) 
+    #return robj
+end
+
+
+#  provide the timing signal:
+function timerInitFun()
+   println("In timerInitFun")
+   return Input(1) 
+end
+
+# How do we get lenPlanet in there?
+function timerAdvanceFun(timer::Reactive.Input{Int64})
+    global lenPlanet
+    push!(timer, mod1(timer.value+1, lenPlanet))
+end
+
+
+end    # SubScreensInline
+
+#==
+For checking:
+
+push!(GLVisualize.ROOT_SCREEN.renderlist, robj)
+append!(GLVisualize.ROOT_SCREEN.renderlist, planet_lines)
+
+@async renderloop() 
+# you can also "manually" push into the signal. For that the renderloop has to be 
+# started asynchronous while the loop that updates the signal is the blocking one
+while GLVisualize.ROOT_SCREEN.inputs[:open].value
+    yield()
+    push!(time_i, mod1(time_i.value+1, lenPlanet))
+end
+
+==#
+   ?>
+   </inline>
+</julia>
+<!-- Subscreen description -->
+ <subscreen rows="2" cols="2" name="MAIN">
+  <rowsizes>1,4</rowsizes>
+  <colsizes>4,1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="A1"/>
+     <subscreen name="A2"/>
+     </tr>
+    <tr>
+     <subscreen name="B1"/>
+     <subscreen name="INNER"/>
+     </tr>
+   </table>
+ </subscreen>
+
+ <subscreen rows="4" cols="1" name="INNER">
+  <rowsizes>1,1,1,1</rowsizes>
+  <colsizes>1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="IA1"/>
+    </tr>
+    <tr>
+     <subscreen name="IB1"/>
+    </tr>
+    <tr>
+     <subscreen name="IC1"/>
+    </tr>
+    <tr>
+     <subscreen name="ID1"/>
+    </tr>
+   </table>
+ </subscreen>
+
+<!-- Subscreen contents -->
+
+ <setplot  ref="B1"  fn="doPlanets">
+       <addparm name="timer" />
+ </setplot>
+
+ <!-- Connectors -->
+
+ <!-- Debug options -->
+
+<debug>
+    <dump ref="B1"/>
+</debug>
+
+</scene>
+<!-- This ends the scene-->

--- a/test/subscreenSpec5.xml
+++ b/test/subscreenSpec5.xml
@@ -26,9 +26,9 @@
       warn ("GLAbstraction.Camera is not exported")
       Camera = GLAbstraction.Camera
 
-      function create_example_axis()
-        dirlen 	= 1f0
-        baselen = 0.02f0
+      function create_example_axis(scale::Float32)
+        dirlen 	= Float32(scale)
+        baselen = 0.02f0*Float32(scale)
         axis 	= [
       	 (Cube(Vec3(baselen), Vec3(dirlen, baselen, baselen)), RGBA(1f0,0f0,0f0,1f0)), 
       	 (Cube(Vec3(baselen), Vec3(baselen, dirlen, baselen)), RGBA(0f0,1f0,0f0,1f0)), 
@@ -38,9 +38,9 @@
         axis = merge(axis)
       end
 
-     function doAxis (sc::Screen,cam::Camera)
+     function doAxis (sc::Screen,cam::Camera,scale::Float32=1.0f0)
           println("Entered doAxis")
-          ax   = create_example_axis()
+          ax   = create_example_axis(scale)
           ax
      end
       end    # SubScreensInline2
@@ -133,9 +133,11 @@ function worldCreate()
    r0[4,:] = [0,0,0.0]
 
    #Select a reasonable set of speeds (avoid cases where
-   #       a singularity happens stopping the ode solver
+   #       a singularity happens stopping the ode solver. Arrange for
+   #       a null momentum so that the world stays on the screen. )
    v0 = rand(n,3)
-
+   mv = m' * v0 / sum(m)
+   v0 = v0 - ones(4,1) * mv
 
 
    # Aggregate initial data (position, speed)  in a format that
@@ -265,7 +267,7 @@ function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result
     # this conversion is required, otherwise loss of type information
     robjPlTy = Array{RenderObject,1}(robjPl)
 
-    return (robj, robjPlTy, doAxis(sc,cam))
+    return (robj, robjPlTy, doAxis(sc,cam,3.0f0))
 end
 
 function doPlanetSpeeds( sc::Screen,cam::Camera, time_i) # beware 3rd result
@@ -294,7 +296,7 @@ function doPlanetSpeeds( sc::Screen,cam::Camera, time_i) # beware 3rd result
     # this conversion is required, otherwise loss of type information
     robjPlTy = Array{RenderObject,1}(robjPl)
 
-    return (robjSpeed, robjPlTy, doAxis(sc,cam))
+    return (robjSpeed, robjPlTy, doAxis(sc,cam,3.0f0))
 end
 
 

--- a/test/subscreenSpec5.xml
+++ b/test/subscreenSpec5.xml
@@ -198,14 +198,6 @@ For checking:
 push!(GLVisualize.ROOT_SCREEN.renderlist, robj)
 append!(GLVisualize.ROOT_SCREEN.renderlist, planet_lines)
 
-@async renderloop() 
-# you can also "manually" push into the signal. For that the renderloop has to be 
-# started asynchronous while the loop that updates the signal is the blocking one
-while GLVisualize.ROOT_SCREEN.inputs[:open].value
-    yield()
-    push!(time_i, mod1(time_i.value+1, lenPlanet))
-end
-
 ==#
    ?>
    </inline>

--- a/test/subscreenSpec6.xml
+++ b/test/subscreenSpec6.xml
@@ -1,21 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
 
 <!-- Test purposes
-      Try the Lorentz attractor
+     1) use a real time timer to sequence timed display(s)
+     2) Currently we have a number of issues for transmission of global or
+        module local data. Therefore using wired in values for some dimensions.
 -->
 <!-- Function definitions  -->
 
 
+<julia  modulename="SubScreensInline2">
+   <inline>
+   <?julia      
+      module SubScreensInline2
+
+      using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+      using ColorTypes, GeometryTypes
+      using Meshes, MeshIO
+      using Romeo, TBCompletedM
+
+      export doMesh, doAxis, doMeshAxis
+      
+      warn ("GLAbstraction.Camera is not exported")
+      Camera = GLAbstraction.Camera
+
+      function create_example_axis(scale::Float32)
+        dirlen 	= Float32(scale)
+        baselen = 0.02f0*Float32(scale)
+        axis 	= [
+      	 (Cube(Vec3(baselen), Vec3(dirlen, baselen, baselen)), RGBA(1f0,0f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, dirlen, baselen)), RGBA(0f0,1f0,0f0,1f0)), 
+      	 (Cube(Vec3(baselen), Vec3(baselen, baselen, dirlen)), RGBA(0f0,0f0,1f0,1f0))
+          ]
+        axis = map(GLNormalMesh, axis)
+        axis = merge(axis)
+      end
+
+     function doAxis (sc::Screen,cam::Camera,scale::Float32=1.0f0)
+          println("Entered doAxis")
+          ax   = create_example_axis(scale)
+          ax
+     end
+      end    # SubScreensInline2
+   ?>
+   </inline>
+</julia>
+
+
+
 <julia  modulename="SubScreensInline">
-   <signal name="timer"  
-           init="timerInitFun" 
-           advance="timerAdvanceFun"
+   <signal name="timer"
+           init="timerInitFun"
            type="Reactive.Input{Int64}"/>
    <!-- now  read the inlined Julia code -->
    <inline>
-   <?julia      
+   <?julia
 module SubScreensInline
 
 using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
@@ -25,17 +65,91 @@ using Reactive
 using Romeo, TBCompletedM
 using ODE
 
-export doPlanets,  timerInitFun, timerAdvanceFun
-      
+using xmlNS.SubScreensInline2
+
+export doPlanets,  doPlanetSpeeds, timerInitFun, timerAdvanceFun
+
 warn ("GLAbstraction.Camera is not exported")
 Camera = GLAbstraction.Camera
 
       ## Example from GLVisualize/test/nbody.jl
 function F(t,y)
-    
+
+    #Number of Planets (note we're solving the n-body problem, rather than just a 3-body problem)
+    n = int(length(y)/6)
+
+    #Extract current position and velocity
+    r = zeros(n,3)
+    v = zeros(n,3)
+    for i=1:n
+        r[i,:] = y[(i-1)*6+1:(i-1)*6+3]
+        v[i,:] = y[(i-1)*6+4:(i-1)*6+6]
+    end
+
+    #Calculate spatial derivatives
+    drdt = v
+
+    #Work out velocity derivatives (ie accelerations)
+    dvdt = zeros(n,3)
+    for i = 1:n
+        for j = 1:n
+            if i != j
+                dvdt[i,:] += -G*m[j]*(r[i,:]-r[j,:])/(norm(r[i,:]-r[j,:])^3)
+            end
+        end
+    end
+
+    #Combine back together into dydt vector
+    dydt = zeros(6*n)
+    for i = 1:n
+        dydt[6(i-1)+1] = drdt[i,1]
+        dydt[6(i-1)+2] = drdt[i,2]
+        dydt[6(i-1)+3] = drdt[i,3]
+        dydt[6(i-1)+4] = dvdt[i,1]
+        dydt[6(i-1)+5] = dvdt[i,2]
+        dydt[6(i-1)+6] = dvdt[i,3]
+    end
+    return dydt
 end  # Function F(t,y)
 
 function worldCreate()
+
+   #Set the masses
+   global m
+   m = [5,4,3,5]
+   n = length(m)
+
+   #Set the gravitational field strength
+   global G
+   G = .2
+
+   #Set initial positions and velocities
+   r0 = zeros(n,3)
+   r0[1,:] = [ 1.0, -1.0,  1.0]
+   r0[2,:] = [ 1.0,  0.0,  0.0]
+   r0[3,:] = [ 0.0,  0.0, -1.0]
+   r0[4,:] = [ 0.0,  0.0,  0.0]
+
+   #Select a reasonable set of speeds (avoid cases where
+   #       a singularity happens stopping the ode solver. Arrange for
+   #       a null momentum so that the world stays on the screen. )
+   v0 = rand(n,3)
+   mv = m' * v0 / sum(m)
+   v0 = v0 - ones(4,1) * mv
+
+
+   # Aggregate initial data (position, speed)  in a format that
+   # the ODE solver and function F handle
+   y0 = zeros(6*n)
+   for i = 1:n
+     y0[6(i-1)+1] = r0[i,1]
+     y0[6(i-1)+2] = r0[i,2]
+     y0[6(i-1)+3] = r0[i,3]
+     y0[6(i-1)+4] = v0[i,1]
+     y0[6(i-1)+5] = v0[i,2]
+     y0[6(i-1)+6] = v0[i,3]
+   end
+    return (m,y0,G)
 end
 
 function worldOperate(y0)
@@ -47,13 +161,35 @@ function worldOperate(y0)
    return t,y
 end
 
+function worldStore()
+    global world
+    if !isdefined(:world)
+        m,y0,G = worldCreate()
+        t,y    = worldOperate(y0)
+        planets      = reformatData(m, t, y)
+        planetspeeds = reformatSpeeds(m, t, y)
+        len= size(planets, 1)
+        world = WorldType(m, length(m), y0, G, t, y, planets, planetspeeds, len)
+    end
+end
+
+function mkParticleColors(n::Int)
+    global particleColors
+    if !isdefined(:particleColors)
+          particleColors = Array{Any,1}(n)
+          for i in 1:n
+             particleColors[i] =  RGBA(rand(Float32,3)..., 0.4f0)
+          end
+    end
+end
+
 function send_frame(i, planets)
     p = planets[i, 1:4]
     reshape(p, (2,2))
 end
 
 function reformatData(m, t, y)
-    #Extract the data into a useful form 
+    #Extract the data into a useful form
     n = length(m)
     ymat= hcat(y...)
 
@@ -64,99 +200,163 @@ function reformatData(m, t, y)
                       [6(i-1)+3 for i = 1:n]])
     rcoords = convert(Array{Int64,1}, rcoords)
     const r = map(Float32, ymat[rcoords,:])
-    
+
     const planets = hcat( [ reinterpret(Point3{Float32},
                                         r[3(i-1)+1:3(i-1)+3,:],
                                         (size(r, 2),)) for i=1:n]...)
-    println("size(planets[:, 1]=", size(planets[:, 1]))                                            
+    println("size(planets[:, 1]=", size(planets[:, 1]))
     return planets
 end
 
 
+function reformatSpeeds(m, t, y)
+    #Extract the data into a useful form
+    n = length(m)
+    ymat= hcat(y...)
 
-function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result   
-    m,y0,G = worldCreate()
-    t,y    = worldOperate(y0)  
-    planets = reformatData(m, t, y)
-    len= size(planets, 1)
+    # gather some results, do we need to construct such an array
+    # positions
+    rcoords = sort([  [6(i-1)+4 for i = 1:n],
+                      [6(i-1)+5 for i = 1:n],
+                      [6(i-1)+6 for i = 1:n]])
+    rcoords = convert(Array{Int64,1}, rcoords)
+    const r = map(Float32, ymat[rcoords,:])
+
+    const speeds = hcat( [ reinterpret(Point3{Float32},
+                                        r[3(i-1)+1:3(i-1)+3,:],
+                                        (size(r, 2),)) for i=1:n]...)
+    return speeds
+end
+
+
+type WorldType
+     masses
+     nb
+     yInit
+     G
+     tsteps
+     YV
+     planets
+     speeds
+     lenPlanets
+end
+
+
+
+function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result
+    global world
+    worldStore()
+
+    global particleColors
+    mkParticleColors(world.nb)
 
     # this is used for communication with timerAdvanceFun
-    global lenPlanet
-    lenPlanet = len    
+    lenPlanet =  world.lenPlanets
 
-    const positions     = lift(send_frame, time_i, Input(planets))
-    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+    const positions     = lift(send_frame, time_i, Input(world.planets))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)),
+                                    screen=sc, camera=cam)
 
 
-    const robjPl  = [ visualize(
-    				reshape(planets[:, i], (round(Int,len/20), 20)),
-				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
-    				model=scalematrix(Vec3(0.01f0)))
+    const robjPl  = [ visualize(reshape(world.planets[:, i], (round(Int,lenPlanet/20), 20)),
+				particle_color= particleColors[i],
+    				model=scalematrix(Vec3(0.01f0)),
+                                screen=sc, camera=cam)
                        for i=1:4]
 
-    # for now I have an issue with the second (robjPl)
-    #return (robj, robjPl, len) 
+    # this conversion is required, otherwise loss of type information
+    robjPlTy = Array{RenderObject,1}(robjPl)
 
-    return robj
+    return (robj, robjPlTy, doAxis(sc,cam,3.0f0))
 end
+
+function doPlanetSpeeds( sc::Screen,cam::Camera, time_i) # beware 3rd result
+    global world
+    worldStore()
+    global particleColors
+    mkParticleColors(world.nb)
+
+    # this is used for communication with timerAdvanceFun
+    lenPlanet =  world.lenPlanets
+
+    speedScale= 3.0
+    @show typeof(world.speeds)
+    const posSpeeds   = lift(send_frame, time_i, Input(world.speeds))
+    const robjSpeed   = visualize(posSpeeds, model=scalematrix(Vec3(0.3f0)),
+                                  screen=sc, camera=cam)
+
+
+    const robjPl  = [ visualize( reshape( world.speeds[:, i] , 
+                                         (round(Int,lenPlanet/20), 20)),
+		particle_color= particleColors[i],
+    		model=scalematrix(Vec3(0.03f0)), 
+                screen=sc, camera=cam)
+                for i=1:4]
+
+    # this conversion is required, otherwise loss of type information
+    robjPlTy = Array{RenderObject,1}(robjPl)
+
+    return (robjSpeed, robjPlTy, doAxis(sc,cam,3.0f0))
+end
+
 
 
 #  provide the timing signal:
 function timerInitFun()
+   lenPlanets = 1950    # wired in for now  (need to understand the context )
+   freq = 0.02  # 1/50  of a second
    println("In timerInitFun")
-   return Input(1) 
-end
-
-# How do we get lenPlanet in there?
-function timerAdvanceFun(timer::Reactive.Input{Int64})
-    global lenPlanet
-    push!(timer, mod1(timer.value+1, lenPlanet))
+   realClk = every(freq)
+   # define a reduction ending in increment (modulo m)
+   moduloAlt = s -> foldl( (x,y) ->  (x+1)%lenPlanets, 0, s)   
+   return moduloAlt(realClk)
 end
 
 
 end    # SubScreensInline
 
+#==
+For checking:
+
+push!(GLVisualize.ROOT_SCREEN.renderlist, robj)
+append!(GLVisualize.ROOT_SCREEN.renderlist, planet_lines)
+
+==#
    ?>
    </inline>
 </julia>
 <!-- Subscreen description -->
- <subscreen rows="2" cols="2" name="MAIN">
+ <subscreen rows="2" cols="1" name="MAIN">
   <rowsizes>1,4</rowsizes>
-  <colsizes>4,1</colsizes>
+  <colsizes>1</colsizes>
   <table>
     <tr>
      <subscreen name="A1"/>
-     <subscreen name="A2"/>
      </tr>
     <tr>
-     <subscreen name="B1"/>
      <subscreen name="INNER"/>
      </tr>
    </table>
  </subscreen>
 
- <subscreen rows="4" cols="1" name="INNER">
-  <rowsizes>1,1,1,1</rowsizes>
-  <colsizes>1</colsizes>
+ <subscreen rows="1" cols="2" name="INNER">
+  <rowsizes>1</rowsizes>
+  <colsizes>1,1</colsizes>
   <table>
     <tr>
      <subscreen name="IA1"/>
-    </tr>
-    <tr>
      <subscreen name="IB1"/>
-    </tr>
-    <tr>
-     <subscreen name="IC1"/>
-    </tr>
-    <tr>
-     <subscreen name="ID1"/>
     </tr>
    </table>
  </subscreen>
 
 <!-- Subscreen contents -->
 
- <setplot  ref="B1"  fn="doPlanets">
+ <setplot  ref="IA1"  fn="doPlanets">
+       <addparm name="timer" />
+ </setplot>
+
+ <setplot  ref="IB1"  fn="doPlanetSpeeds">
        <addparm name="timer" />
  </setplot>
 
@@ -165,7 +365,6 @@ end    # SubScreensInline
  <!-- Debug options -->
 
 <debug>
-    <dump ref="B1"/>
 </debug>
 
 </scene>

--- a/test/subscreenSpec6.xml
+++ b/test/subscreenSpec6.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
+
+<!-- Test purposes
+      Try the Lorentz attractor
+-->
+<!-- Function definitions  -->
+
+
+<julia  modulename="SubScreensInline">
+   <signal name="timer"  
+           init="timerInitFun" 
+           advance="timerAdvanceFun"
+           type="Reactive.Input{Int64}"/>
+   <!-- now  read the inlined Julia code -->
+   <inline>
+   <?julia      
+module SubScreensInline
+
+using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+using ColorTypes, GeometryTypes
+using Meshes, MeshIO
+using Reactive
+using Romeo, TBCompletedM
+using ODE
+
+export doPlanets,  timerInitFun, timerAdvanceFun
+      
+warn ("GLAbstraction.Camera is not exported")
+Camera = GLAbstraction.Camera
+
+      ## Example from GLVisualize/test/nbody.jl
+function F(t,y)
+    
+end  # Function F(t,y)
+
+function worldCreate()
+end
+
+function worldOperate(y0)
+   #Solve the system
+   tf = 10
+   stepsPerUnitTime = 200
+   tspan = linspace(0,tf,tf*stepsPerUnitTime)
+   t,y = ode23s(F, y0, tspan; points=:specified);
+   return t,y
+end
+
+function send_frame(i, planets)
+    p = planets[i, 1:4]
+    reshape(p, (2,2))
+end
+
+function reformatData(m, t, y)
+    #Extract the data into a useful form 
+    n = length(m)
+    ymat= hcat(y...)
+
+    # gather some results, do we need to construct such an array
+    # positions
+    rcoords = sort([  [6(i-1)+1 for i = 1:n],
+                      [6(i-1)+2 for i = 1:n],
+                      [6(i-1)+3 for i = 1:n]])
+    rcoords = convert(Array{Int64,1}, rcoords)
+    const r = map(Float32, ymat[rcoords,:])
+    
+    const planets = hcat( [ reinterpret(Point3{Float32},
+                                        r[3(i-1)+1:3(i-1)+3,:],
+                                        (size(r, 2),)) for i=1:n]...)
+    println("size(planets[:, 1]=", size(planets[:, 1]))                                            
+    return planets
+end
+
+
+
+function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result   
+    m,y0,G = worldCreate()
+    t,y    = worldOperate(y0)  
+    planets = reformatData(m, t, y)
+    len= size(planets, 1)
+
+    # this is used for communication with timerAdvanceFun
+    global lenPlanet
+    lenPlanet = len    
+
+    const positions     = lift(send_frame, time_i, Input(planets))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+
+
+    const robjPl  = [ visualize(
+    				reshape(planets[:, i], (round(Int,len/20), 20)),
+				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
+    				model=scalematrix(Vec3(0.01f0)))
+                       for i=1:4]
+
+    # for now I have an issue with the second (robjPl)
+    #return (robj, robjPl, len) 
+
+    return robj
+end
+
+
+#  provide the timing signal:
+function timerInitFun()
+   println("In timerInitFun")
+   return Input(1) 
+end
+
+# How do we get lenPlanet in there?
+function timerAdvanceFun(timer::Reactive.Input{Int64})
+    global lenPlanet
+    push!(timer, mod1(timer.value+1, lenPlanet))
+end
+
+
+end    # SubScreensInline
+
+   ?>
+   </inline>
+</julia>
+<!-- Subscreen description -->
+ <subscreen rows="2" cols="2" name="MAIN">
+  <rowsizes>1,4</rowsizes>
+  <colsizes>4,1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="A1"/>
+     <subscreen name="A2"/>
+     </tr>
+    <tr>
+     <subscreen name="B1"/>
+     <subscreen name="INNER"/>
+     </tr>
+   </table>
+ </subscreen>
+
+ <subscreen rows="4" cols="1" name="INNER">
+  <rowsizes>1,1,1,1</rowsizes>
+  <colsizes>1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="IA1"/>
+    </tr>
+    <tr>
+     <subscreen name="IB1"/>
+    </tr>
+    <tr>
+     <subscreen name="IC1"/>
+    </tr>
+    <tr>
+     <subscreen name="ID1"/>
+    </tr>
+   </table>
+ </subscreen>
+
+<!-- Subscreen contents -->
+
+ <setplot  ref="B1"  fn="doPlanets">
+       <addparm name="timer" />
+ </setplot>
+
+ <!-- Connectors -->
+
+ <!-- Debug options -->
+
+<debug>
+    <dump ref="B1"/>
+</debug>
+
+</scene>
+<!-- This ends the scene-->

--- a/test/subscreenSpec7.xml
+++ b/test/subscreenSpec7.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scene xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:noNamespaceSchemaLocation="subscreenSchema.xsd">
+
+<!-- Test purposes
+      Try the Lorentz attractor
+-->
+<!-- Function definitions  -->
+
+
+<julia  modulename="SubScreensInline">
+   <signal name="timer"  
+           init="timerInitFun" 
+           advance="timerAdvanceFun"
+           type="Reactive.Input{Int64}"/>
+   <!-- now  read the inlined Julia code -->
+   <inline>
+   <?julia      
+module SubScreensInline
+
+using GLAbstraction, GLWindow, ModernGL, GLVisualize,  AbstractGPUArray
+using ColorTypes, GeometryTypes
+using Meshes, MeshIO
+using Reactive
+using Romeo, TBCompletedM
+using ODE
+
+export doPlanets,  timerInitFun, timerAdvanceFun
+      
+warn ("GLAbstraction.Camera is not exported")
+Camera = GLAbstraction.Camera
+
+      ## Example from GLVisualize/test/nbody.jl
+function F(t,y)
+    
+end  # Function F(t,y)
+
+function worldCreate()
+end
+
+function worldOperate(y0)
+   #Solve the system
+   tf = 10
+   stepsPerUnitTime = 200
+   tspan = linspace(0,tf,tf*stepsPerUnitTime)
+   t,y = ode23s(F, y0, tspan; points=:specified);
+   return t,y
+end
+
+function send_frame(i, planets)
+    p = planets[i, 1:4]
+    reshape(p, (2,2))
+end
+
+function reformatData(m, t, y)
+    #Extract the data into a useful form 
+    n = length(m)
+    ymat= hcat(y...)
+
+    # gather some results, do we need to construct such an array
+    # positions
+    rcoords = sort([  [6(i-1)+1 for i = 1:n],
+                      [6(i-1)+2 for i = 1:n],
+                      [6(i-1)+3 for i = 1:n]])
+    rcoords = convert(Array{Int64,1}, rcoords)
+    const r = map(Float32, ymat[rcoords,:])
+    
+    const planets = hcat( [ reinterpret(Point3{Float32},
+                                        r[3(i-1)+1:3(i-1)+3,:],
+                                        (size(r, 2),)) for i=1:n]...)
+    println("size(planets[:, 1]=", size(planets[:, 1]))                                            
+    return planets
+end
+
+
+
+function doPlanets( sc::Screen,cam::Camera, time_i) # beware 3rd result   
+    m,y0,G = worldCreate()
+    t,y    = worldOperate(y0)  
+    planets = reformatData(m, t, y)
+    len= size(planets, 1)
+
+    # this is used for communication with timerAdvanceFun
+    global lenPlanet
+    lenPlanet = len    
+
+    const positions     = lift(send_frame, time_i, Input(planets))
+    const robj          = visualize(positions, model=scalematrix(Vec3(0.1f0)))
+
+
+    const robjPl  = [ visualize(
+    				reshape(planets[:, i], (round(Int,len/20), 20)),
+				particle_color=RGBA(rand(Float32,3)..., 0.4f0),
+    				model=scalematrix(Vec3(0.01f0)))
+                       for i=1:4]
+
+    # for now I have an issue with the second (robjPl)
+    #return (robj, robjPl, len) 
+
+    return robj
+end
+
+
+#  provide the timing signal:
+function timerInitFun()
+   println("In timerInitFun")
+   return Input(1) 
+end
+
+# How do we get lenPlanet in there?
+function timerAdvanceFun(timer::Reactive.Input{Int64})
+    global lenPlanet
+    push!(timer, mod1(timer.value+1, lenPlanet))
+end
+
+
+end    # SubScreensInline
+
+   ?>
+   </inline>
+</julia>
+<!-- Subscreen description -->
+ <subscreen rows="2" cols="2" name="MAIN">
+  <rowsizes>1,4</rowsizes>
+  <colsizes>4,1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="A1"/>
+     <subscreen name="A2"/>
+     </tr>
+    <tr>
+     <subscreen name="B1"/>
+     <subscreen name="INNER"/>
+     </tr>
+   </table>
+ </subscreen>
+
+ <subscreen rows="4" cols="1" name="INNER">
+  <rowsizes>1,1,1,1</rowsizes>
+  <colsizes>1</colsizes>
+  <table>
+    <tr>
+     <subscreen name="IA1"/>
+    </tr>
+    <tr>
+     <subscreen name="IB1"/>
+    </tr>
+    <tr>
+     <subscreen name="IC1"/>
+    </tr>
+    <tr>
+     <subscreen name="ID1"/>
+    </tr>
+   </table>
+ </subscreen>
+
+<!-- Subscreen contents -->
+
+ <setplot  ref="B1"  fn="doPlanets">
+       <addparm name="timer" />
+ </setplot>
+
+ <!-- Connectors -->
+
+ <!-- Debug options -->
+
+<debug>
+    <dump ref="B1"/>
+</debug>
+
+</scene>
+<!-- This ends the scene-->


### PR DESCRIPTION
Hi, 

this solves partly the issue:
- typing is now apparently satisfactory
- added `yield()` in signal update loop
- I do not like the syntax I used in `doPlanet` to retype;wondering whether I ought to hide this
  in `visualizeConduit` 
  *this example is now in `test/subscreenSpec5.xml`

However, mouse only works in this case for zoom (with the roller), no rotations nor translations.
(Probably the mouse signal got lost in my code....)

**I still need to make planet lines appear...** but this will wait for tomorrow or Monday. So don't worry about these issues, I will try to solve them later
